### PR TITLE
Update the library to utilize composer and namespacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-
+.DS_Store
 *.swp
 *.swo
+
+/vendor/

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,14 @@
 # Ranker
 A simple class to assign rankings to objects in an array based on one of their properties.
 
-#### Usage  
+#### Usage
+
+Include in your project using Composer:
+
+```
+composer require joeyquarters/php-ranker
+```
+
 Use `useStrategy()` to choose one of the predefined strategies:
 
 ```
@@ -11,43 +18,46 @@ Use `useStrategy()` to choose one of the predefined strategies:
 'ordinal'     : Ordinal Ranking               ( 1234 )
 ```
 
-   
+
 Then use `$ranker->rank($objectsToRank)` to apply the rankings to an array of objects to rank.
 
-#### Example  
+#### Example
 ```php
 <?php
+
+use Ranker\Ranker;
+
 $objectsToRank = array(
    (object) array( 'name' => 'first',      'points' => 100 ),
    (object) array( 'name' => 'second (1)', 'points' => 75 ),
    (object) array( 'name' => 'second (2)', 'points' => 75 ),
    (object) array( 'name' => 'third',      'points' => 50 ),
 );
-    
+
 $ranker = new Ranker();
 $ranker
    ->useStrategy('dense')      // Use the dense ranking strategy
    ->orderBy('points')         // Property to base ranking on, Default is 'score'
    ->storeRankingIn('ranked')  // Default is 'ranking'
-   ->rank($objectsToRank);  
-   
+   ->rank($objectsToRank);
+
 print_r($objectsToRank);
 ```
 
 This will output something like:
 
 ```
-Array ( 
-   [0] => stdClass Object ( [name] => first      [points] => 100   [ranked] => 1 ) 
-   [1] => stdClass Object ( [name] => second (1) [points] => 75    [ranked] => 2 ) 
-   [2] => stdClass Object ( [name] => second (2) [points] => 75    [ranked] => 2 ) 
-   [3] => stdClass Object ( [name] => third      [points] => 50    [ranked] => 3 ) 
+Array (
+   [0] => stdClass Object ( [name] => first      [points] => 100   [ranked] => 1 )
+   [1] => stdClass Object ( [name] => second (1) [points] => 75    [ranked] => 2 )
+   [2] => stdClass Object ( [name] => second (2) [points] => 75    [ranked] => 2 )
+   [3] => stdClass Object ( [name] => third      [points] => 50    [ranked] => 3 )
 )
 ```
 
 #### Ranking already sorted items
 
-If you've fetched some objects from the database which have already been sorted then you can 
+If you've fetched some objects from the database which have already been sorted then you can
 set the second parameter of `rank()` to `FALSE`. This will improve your performance when ranking large arrays.
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "nichols/php-ranker",
+    "description": "A simple class to assign rankings to objects in an array based on one of their properties.",
+    "type": "library",
+    "license": "Apache-2.0",
+    "authors": [
+        {
+            "name": "Maarten Claes",
+            "email": "maartencls@gmail.com"
+        },
+        {
+            "name": "Joey Nichols",
+            "email": "joeyquarters@gmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0"
+    },
+    "autoload": {
+        "psr-4": {
+          "Ranker\\": "lib/"
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "nichols/php-ranker",
+    "name": "joeyquarters/php-ranker",
     "description": "A simple class to assign rankings to objects in an array based on one of their properties.",
     "type": "library",
     "license": "Apache-2.0",

--- a/lib/Ranker.php
+++ b/lib/Ranker.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2012 Maarten Claes 
+ * Copyright 2012 Maarten Claes
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-include 'src/RankingStrategy.php';
-include 'src/StandardCompetitionStrategy.php';
-include 'src/ModifiedCompetitionStrategy.php';
-include 'src/DenseStrategy.php';
-include 'src/OrdinalStrategy.php';
+
+namespace Ranker;
+
+use Ranker\RankingStrategy\Ordinal;
+use Ranker\RankingStrategy\StandardCompetition;
+use Ranker\RankingStrategy\ModifiedCompetition;
+use Ranker\RankingStrategy\Dense;
 
 class Ranker {
-  
+
   // Ranking strategy
-  private $strategyName = 'ordinal'; 
+  private $strategyName = 'ordinal';
   private $strategy;
   // Options
   private $rankingProperty = 'ranking';
@@ -31,11 +33,11 @@ class Ranker {
   private $descending = TRUE;
 
   public function __construct() {
-    $this->strategy = new OrdinalStrategy();
+    $this->strategy = new Ordinal();
   }
-  
+
   /**
-   * Sets a ranking strategy. The possibilities are:  
+   * Sets a ranking strategy. The possibilities are:
    * - 'competition' : Standard Competition Ranking ( 1224 )
    * - 'modified'    : Modified Competition Ranking ( 1334 )
    * - 'dense'       : Dense Ranking                ( 1223 )
@@ -46,20 +48,20 @@ class Ranker {
   public function useStrategy($strategyName) {
     switch ($strategyName) {
       case 'competition':
-        $this->strategy = new StandardCompetitionStrategy();
+        $this->strategy = new StandardCompetition();
         break;
       case 'modified':
-        $this->strategy = new ModifiedCompetitionStrategy();
+        $this->strategy = new ModifiedCompetition();
         break;
       case 'dense':
-        $this->strategy = new DenseStrategy();
+        $this->strategy = new Dense();
         break;
       case 'ordinal':
-        $this->strategy = new OrdinalStrategy();
+        $this->strategy = new Ordinal();
         break;
       default:
-        throw new UnknownRankingStrategyException("Ranking strategy '$strategyName' not found!");
-    } 
+        throw new \Exception("Ranking strategy '$strategyName' not found!");
+    }
     $this->strategyName = $strategyName;
     return $this;
   }
@@ -89,7 +91,7 @@ class Ranker {
   }
 
   /**
-   * Ranks and sorts the provided array. The ranking number will be added to 
+   * Ranks and sorts the provided array. The ranking number will be added to
    * the 'ranking' property of the objects.
    * @param Array &$rankables Array of objects to rank
    * @param Boolean $sortBeforeRanking Whether or not to sort the rankables before asigning ranks
@@ -104,7 +106,7 @@ class Ranker {
   }
 
   /**
-   * Sort the provided array without assigning rankings. 
+   * Sort the provided array without assigning rankings.
    * @param Array &$rankables Array of objects to sort.
    * @param Boolean $descending Ascending or descending.
    */
@@ -131,5 +133,3 @@ class Ranker {
   }
 
 }
-
-class UnknownRankingStrategyException extends Exception {}

--- a/lib/RankingStrategy/Base.php
+++ b/lib/RankingStrategy/Base.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2012 Maarten Claes 
+ * Copyright 2012 Maarten Claes
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-abstract class RankingStrategy {
+
+namespace Ranker\RankingStrategy;
+
+abstract class Base {
 
   protected $orderBy = 'score';
   protected $rankingProperty = 'ranking';
@@ -23,7 +26,7 @@ abstract class RankingStrategy {
   public function setOrderBy($property) {
     $this->orderBy = $property;
   }
- 
+
   /**
    * Set the property to store the ranking in.
    * @param String $property Ranking property
@@ -58,7 +61,7 @@ abstract class RankingStrategy {
   abstract protected function whenEqual($rankable, $ranking_index);
 
   abstract protected function whenDifferent($rankable, $ranking_index);
-  
+
   protected function setRanking(&$rankable, $ranking) {
     $rankable->{$this->rankingProperty} = $ranking;
   }

--- a/lib/RankingStrategy/Dense.php
+++ b/lib/RankingStrategy/Dense.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2012 Maarten Claes 
+ * Copyright 2012 Maarten Claes
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
+namespace Ranker\RankingStrategy;
+
 /**
  * Dense ranking strategy ( 1223 )
- */ 
-class DenseStrategy extends RankingStrategy {
+ */
+class Dense extends Base {
 
   protected function whenEqual($rankable, $ranking_index) {
     $this->setRanking($rankable, $this->last_rankable->ranking);
@@ -28,4 +30,4 @@ class DenseStrategy extends RankingStrategy {
     $this->setRanking($rankable, $this->last_rankable->ranking + 1);
   }
 
-} 
+}

--- a/lib/RankingStrategy/ModifiedCompetition.php
+++ b/lib/RankingStrategy/ModifiedCompetition.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2012 Maarten Claes 
+ * Copyright 2012 Maarten Claes
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
+namespace Ranker\RankingStrategy;
+
 /**
  * Modified competition strategy ( 1334 )
- * Leaves the gaps in the ranking numbers before the sets of equal-ranking 
+ * Leaves the gaps in the ranking numbers before the sets of equal-ranking
  * items (rather than after them as in standard competition ranking)
  */
-class ModifiedCompetitionStrategy extends RankingStrategy {
+class ModifiedCompetition extends Base {
 
   private $equalRanking = array();
 
   protected function whenEqual($rankable, $ranking_index) {
     $this->updateEqualRankingItems($rankable, $ranking_index);
   }
-  
+
   private function updateEqualRankingItems($rankable, $ranking_index) {
     $this->equalRanking[] = $rankable;
     // ranking = value after gap = $ranking_index + 1

--- a/lib/RankingStrategy/Ordinal.php
+++ b/lib/RankingStrategy/Ordinal.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2012 Maarten Claes 
+ * Copyright 2012 Maarten Claes
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-/**
- * Standard competition strategy ( 1224 )
- */ 
-class StandardCompetitionStrategy extends RankingStrategy {
-  
-  protected function whenEqual($rankable, $ranking_index) {
-    $this->setRanking($rankable, $this->last_rankable->ranking);
-  }
 
-  protected function whenDifferent($rankable, $ranking_index) {
+namespace Ranker\RankingStrategy;
+
+/**
+ * Ordinal ranking strategy ( 1234 )
+ */
+class Ordinal extends Base {
+
+  protected function assignRanking($rankable, $ranking_index) {
     $this->setRanking($rankable, $ranking_index + 1);
   }
 
+  // Not used
+  protected function whenEqual($rankable, $ranking_index) {}
+  protected function whenDifferent($rankable, $ranking_index) {}
+
 }
+

--- a/lib/RankingStrategy/StandardCompetition.php
+++ b/lib/RankingStrategy/StandardCompetition.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2012 Maarten Claes 
+ * Copyright 2012 Maarten Claes
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-/**
- * Ordinal ranking strategy ( 1234 )
- */ 
-class OrdinalStrategy extends RankingStrategy {
 
-  protected function assignRanking($rankable, $ranking_index) {
+namespace Ranker\RankingStrategy;
+
+/**
+ * Standard competition strategy ( 1224 )
+ */
+class StandardCompetition extends Base {
+
+  protected function whenEqual($rankable, $ranking_index) {
+    $this->setRanking($rankable, $this->last_rankable->ranking);
+  }
+
+  protected function whenDifferent($rankable, $ranking_index) {
     $this->setRanking($rankable, $ranking_index + 1);
   }
-  
-  // Not used
-  protected function whenEqual($rankable, $ranking_index) {}
-  protected function whenDifferent($rankable, $ranking_index) {}
 
 }
-

--- a/test/RankerTest.php
+++ b/test/RankerTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Ranker\Ranker;
+
 class RankerTest extends PHPUnit_Framework_TestCase {
 
   private $rankables = array();
@@ -7,17 +10,17 @@ class RankerTest extends PHPUnit_Framework_TestCase {
   public function setUp() {
     $this->ranker = new Ranker();
 
-    $this->rankables[] = $this->createRankable("bbb", 75);  
-    $this->rankables[] = $this->createRankable("ddd", 50);  
-    $this->rankables[] = $this->createRankable("ccc", 75);  
-    $this->rankables[] = $this->createRankable("aaa", 100);  
+    $this->rankables[] = $this->createRankable("bbb", 75);
+    $this->rankables[] = $this->createRankable("ddd", 50);
+    $this->rankables[] = $this->createRankable("ccc", 75);
+    $this->rankables[] = $this->createRankable("aaa", 100);
 
-    $this->rankables[] = $this->createRankable("eee", 5);  
-    $this->rankables[] = $this->createRankable("fff", 5);  
-    $this->rankables[] = $this->createRankable("ggg", 5);  
-    
-    $this->rankables[] = $this->createRankable("hhh", 1);  
-    $this->rankables[] = $this->createRankable("iii", 0);  
+    $this->rankables[] = $this->createRankable("eee", 5);
+    $this->rankables[] = $this->createRankable("fff", 5);
+    $this->rankables[] = $this->createRankable("ggg", 5);
+
+    $this->rankables[] = $this->createRankable("hhh", 1);
+    $this->rankables[] = $this->createRankable("iii", 0);
   }
 
   private function createRankable($name, $score, $rankingProperty = 'ranking') {
@@ -29,13 +32,17 @@ class RankerTest extends PHPUnit_Framework_TestCase {
     );
   }
 
+  public function testInstanceOfRanker() {
+    $this->assertInstanceOf('Ranker\Ranker', $this->ranker);
+  }
+
   public function testSettingRankingStrategy() {
     $this->ranker->useStrategy('competition');
     $this->assertEquals("competition", $this->ranker->getRankingStrategy());
   }
- 
+
   /**
-   * @expectedException UnknownRankingStrategyException
+   * @expectedException Exception
    */
   public function testSettingNonExistingRankingStrategyThrowsException() {
     $this->ranker->useStrategy('dmsqlfkjds');
@@ -45,7 +52,7 @@ class RankerTest extends PHPUnit_Framework_TestCase {
     $this->ranker->sort($this->rankables);
     $this->assertFirstAndLastNameValue('aaa', 'iii');
   }
-  
+
   public function testSortAscending() {
     $this->ranker->orderBy('score', FALSE);
     $this->ranker->sort($this->rankables);
@@ -59,12 +66,12 @@ class RankerTest extends PHPUnit_Framework_TestCase {
     $actual_last = $this->rankables[$last]->name;
     $this->assertEquals($expected_last, $actual_last);
   }
-  
+
   public function testCompetitionRanking() {
     $this->applyRankingStrategy('competition');
     $this->assertRanking("122455589", $this->rankables);
   }
-  
+
   public function testModifiedCompetitionRanking() {
     $this->applyRankingStrategy('modified');
     $this->assertRanking("133477789", $this->rankables);
@@ -74,27 +81,27 @@ class RankerTest extends PHPUnit_Framework_TestCase {
     $this->applyRankingStrategy('dense');
     $this->assertRanking("122344456", $this->rankables);
   }
-  
+
   public function testOrdinalRanking() {
     $this->applyRankingStrategy('ordinal');
     $this->assertRanking("123456789", $this->rankables);
     $this->assertFirstAndLastNameValue('aaa', 'iii');
   }
-  
+
   public function testSettingOrderBy() {
     $this->ranker->orderBy('inverseScore');
     $this->applyRankingStrategy('ordinal');
     $this->assertRanking("123456789", $this->rankables);
     $this->assertFirstAndLastNameValue('iii', 'aaa');
   }
-  
+
   public function testAlternativeRankingProperty() {
     $this->ranker->storeRankingIn('alternateRankingProperty');
     $this->applyRankingStrategy('ordinal');
 
     $this->assertEquals(1, $this->rankables[0]->alternateRankingProperty);
   }
-  
+
   /**
    * Helper to test ranking strategies
    */
@@ -103,8 +110,8 @@ class RankerTest extends PHPUnit_Framework_TestCase {
       ->useStrategy($strategy)
       ->rank($this->rankables);
   }
-  
-  /** 
+
+  /**
    * Helps asserting ranking methods work as expected.
    */
   private function assertRanking($expected, $rankables) {

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,2 +1,3 @@
 <?php
-require 'Ranker.php';
+
+require('vendor/autoload.php');


### PR DESCRIPTION
This package is a nice utility that can benefit from Composer support and namespacing, since Ranker is not a very unique class name. 

This pull request contains a file structure refactoring for PSR-4 autoloading, so it will break anyone using the library previously with `require('../php-ranker/Ranker.php');`

A composer.json file has been added. All classes are also namespaced under 'Ranker'. The ranking strategies have a namespace 'Ranker\RankingStrategy'.

Open to any suggestions and criticisms, hope this is a beneficial change!