### PR TITLE
Update ranking property usage for competition ranking

### DIFF
--- a/lib/RankingStrategy/StandardCompetition.php
+++ b/lib/RankingStrategy/StandardCompetition.php
@@ -23,7 +23,7 @@ namespace Ranker\RankingStrategy;
 class StandardCompetition extends Base {
 
   protected function whenEqual($rankable, $ranking_index) {
-    $this->setRanking($rankable, $this->last_rankable->ranking);
+     $this->setRanking($rankable, $this->last_rankable->{$this->rankingProperty});
   }
 
   protected function whenDifferent($rankable, $ranking_index) {


### PR DESCRIPTION
Defaults were used instead of the parent property to get the ranking property. Thus, if changed, resulted in a null value on equal ranks.  Code updated to use parent's property instead.